### PR TITLE
for-of -> traditional for

### DIFF
--- a/src/renderer/models/BrushTool.ts
+++ b/src/renderer/models/BrushTool.ts
@@ -88,8 +88,10 @@ class BrushTool extends BaseBrushTool {
     ]
     const vertices = new Float32Array(waypoints.length * 20)
     const indices = new Uint16Array(waypoints.length * 6)
-    for (const [i, {pos, pressure}] of waypoints.entries()) {
-      for (const [j, offset] of offsets.entries()) {
+    for (let i = 0; i < waypoints.length; ++i) {
+      const {pos, pressure} = waypoints[i]
+      for (let j = 0; j < 4; ++j) {
+        const offset = offsets[j]
         vertices.set([offset.x, offset.y, pos.x, pos.y, pressure], i * 20 + j * 5)
       }
       indices.set(relIndices.map(j => j + i * 4), i * 6)

--- a/src/renderer/models/WatercolorTool.ts
+++ b/src/renderer/models/WatercolorTool.ts
@@ -193,7 +193,8 @@ class WatercolorTool extends BaseBrushTool {
   }
 
   renderWaypoints(waypoints: Waypoint[]) {
-    for (const [i, waypoint] of waypoints.entries()) {
+    for (let i = 0; i < waypoints.length; ++i) {
+      const waypoint = waypoints[i]
       for (const shader of this.shaders) {
         shader.setUniform("uBrushPos", waypoint.pos)
         shader.setUniform("uPressure", waypoint.pressure)


### PR DESCRIPTION
## what

Rewrite `for-of` with traditional `for` in `renderWaypoints` method
## why

`for-of` is slow

before:

[![https://gyazo.com/625090457bd4f2c1a06ad9d6707f34a8](https://i.gyazo.com/625090457bd4f2c1a06ad9d6707f34a8.png)](https://gyazo.com/625090457bd4f2c1a06ad9d6707f34a8)

after:

[![https://gyazo.com/8563b2dfc5d21ddfc5b862e66c79f445](https://i.gyazo.com/8563b2dfc5d21ddfc5b862e66c79f445.png)](https://gyazo.com/8563b2dfc5d21ddfc5b862e66c79f445)
