### PR TITLE
Improve WebGL API usage

### DIFF
--- a/src/lib/GL.ts
+++ b/src/lib/GL.ts
@@ -144,6 +144,46 @@ class Geometry {
 }
 
 export
+class Uniform {
+  location: WebGLUniformLocation
+
+  constructor(public context: Context, public shader: Shader, public name: string) {
+    const {gl} = context
+    this.location = gl.getUniformLocation(shader.program, name)!
+  }
+
+  setInt(value: number) {
+    const {gl} = this.context
+    gl.useProgram(this.shader.program)
+    gl.uniform1i(this.location, value)
+  }
+
+  setFloat(value: number) {
+    const {gl} = this.context
+    gl.useProgram(this.shader.program)
+    gl.uniform1f(this.location, value)
+  }
+
+  setVec2(value: Vec2) {
+    const {gl} = this.context
+    gl.useProgram(this.shader.program)
+    gl.uniform2fv(this.location, value.toGLData())
+  }
+
+  setVec4(value: Vec4) {
+    const {gl} = this.context
+    gl.useProgram(this.shader.program)
+    gl.uniform4fv(this.location, value.toGLData())
+  }
+
+  setTransform(value: Transform) {
+    const {gl} = this.context
+    gl.useProgram(this.shader.program)
+    gl.uniformMatrix3fv(this.location, false, value.toGLData())
+  }
+}
+
+export
 class Shader {
   program: WebGLProgram
 
@@ -169,24 +209,8 @@ class Shader {
     gl.attachShader(this.program, shader)
   }
 
-  setUniformInt(name: string, value: number) {
-    const {gl} = this.context
-    gl.useProgram(this.program)
-    gl.uniform1i(gl.getUniformLocation(this.program, name)!, value)
-  }
-
-  setUniform(name: string, value: number|Vec2|Vec4|Transform) {
-    const {gl} = this.context
-    gl.useProgram(this.program)
-    if (value instanceof Vec2) {
-      gl.uniform2fv(gl.getUniformLocation(this.program, name)!, value.toGLData())
-    } else if (value instanceof Vec4) {
-      gl.uniform4fv(gl.getUniformLocation(this.program, name)!, value.toGLData())
-    } else if (value instanceof Transform) {
-      gl.uniformMatrix3fv(gl.getUniformLocation(this.program, name)!, false, value.toGLData())
-    } else {
-      gl.uniform1f(gl.getUniformLocation(this.program, name)!, value)
-    }
+  uniform(name: string) {
+    return new Uniform(this.context, this, name)
   }
 }
 

--- a/src/renderer/models/BrushTool.ts
+++ b/src/renderer/models/BrushTool.ts
@@ -66,11 +66,11 @@ class BrushTool extends BaseBrushTool {
     const transform =
       Transform.scale(new Vec2(2 / layerSize.width, 2 / layerSize.height))
         .merge(Transform.translate(new Vec2(-1, -1)))
-    this.shader.setUniform('uTransform', transform)
-    this.shader.setUniform('uBrushSize', this.width)
-    this.shader.setUniform('uColor', this.color)
-    this.shader.setUniform('uOpacity', this.opacity)
-    this.shader.setUniform('uMinWidthRatio', this.minWidthRatio)
+    this.shader.uniform('uTransform').setTransform(transform)
+    this.shader.uniform('uBrushSize').setFloat(this.width)
+    this.shader.uniform('uColor').setVec4(this.color)
+    this.shader.uniform('uOpacity').setFloat(this.opacity)
+    this.shader.uniform('uMinWidthRatio').setFloat(this.minWidthRatio)
 
     return super.start(waypoint)
   }

--- a/src/renderer/views/Renderer.ts
+++ b/src/renderer/views/Renderer.ts
@@ -100,10 +100,10 @@ class Renderer {
       context.setScissor(this.transforms.pictureToGLViewport.transformRect(rectInPicture))
     }
     context.clear()
-    this.backgroundShader.setUniform("uTransform", this.transforms.pictureToGLUnit)
+    this.backgroundShader.uniform("uTransform").setTransform(this.transforms.pictureToGLUnit)
     this.backgroundModel.render()
-    this.layerShader.setUniform("uTransform", this.transforms.pictureToGLUnit)
-    this.layerShader.setUniformInt("uTexture", 0)
+    this.layerShader.uniform("uTransform").setTransform(this.transforms.pictureToGLUnit)
+    this.layerShader.uniform("uTexture").setInt(0)
     for (const layer of this.picture.layers) {
       context.textureUnits.set(0, layer.texture)
       this.layerModel.render()


### PR DESCRIPTION
## what

Improve WebGL API usage for better speed
- Reduce `getUniformLocation` calls
- Reduce use of closures
- Remove unnecessary `bindFramebuffer`/`bindTexture`
### before

[![https://gyazo.com/90c5f4190da59422ade5d18fd198071a](https://i.gyazo.com/90c5f4190da59422ade5d18fd198071a.png)](https://gyazo.com/90c5f4190da59422ade5d18fd198071a)
### after

[![https://gyazo.com/d662d8e4e0431e915ef4743200a8d5d7](https://i.gyazo.com/d662d8e4e0431e915ef4743200a8d5d7.png)](https://gyazo.com/d662d8e4e0431e915ef4743200a8d5d7)
