### PR TITLE
Enhance performance of ColorPicker

### DIFF
--- a/src/lib/Color.ts
+++ b/src/lib/Color.ts
@@ -96,6 +96,15 @@ class Color extends Vec4{
   get v() {
     return this.z
   }
+  set h(val) {
+    this.x = val
+  }
+  set s(val) {
+    this.y = val
+  }
+  set v(val) {
+    this.z = val
+  }
 
   // r: 0 ... 1
   // g: 0 ... 1

--- a/src/renderer/views/ColorPicker.tsx
+++ b/src/renderer/views/ColorPicker.tsx
@@ -106,12 +106,15 @@ class ColorPicker extends React.Component<ColorPickerProps, {}> {
   drawSquare() {
     const image = this.squareGradient
     const center = new Vec2(squareSize / 2, squareSize / 2)
-
+    const temporaryColor = new Color(0, 0, 0, 1)
     for (let y = 0; y < squareSize; ++y) {
       for (let x = 0; x < squareSize; ++x) {
         const pos = new Vec2(x + 0.5, y + 0.5).sub(center)
         const {s, v} = this.posToSV(pos)
-        const color = Color.hsv(this.props.color.h, s, v).toRgb()
+        temporaryColor.h = this.props.color.h
+        temporaryColor.s = s
+        temporaryColor.v = v
+        const color = temporaryColor.toRgb()
         setPixel(image, x, y, color)
       }
     }


### PR DESCRIPTION
Constructing Color object each time is too slow. So I split it out as a temporary object and reuse it.
![profiles](https://cloud.githubusercontent.com/assets/5278817/19230575/42fb8b7c-8f10-11e6-85fa-08378eb08f14.png)
