### PR TITLE
Livereload

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -8,13 +8,14 @@
     <div id="app"></div>
   </body>
   <script>
-    require("./assets/renderer.js");
-    // for auto-reloading
-    if(process.env.NODE_ENV === "development") {
-      let {ipcRenderer} = require('electron');
-      ipcRenderer.on('notify-update', (event, arg) => {
-        location.reload();
-      });
-    }
+    (() => {
+      require("./assets/renderer.js")
+      if(process.env.NODE_ENV==="development") {
+        const fs = require("fs")
+        fs.watch(__dirname, { recursive: true }, (eventType, filename) => {
+          location.reload()
+        })
+      }
+    })()
   </script>
 </html>

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,4 @@
 import Electron = require('electron')
-import * as fs from "fs"
 type BrowserWindow = Electron.BrowserWindow
 const {app, BrowserWindow} = Electron
 import {TabletEventReceiver} from "receive-tablet-event"
@@ -14,9 +13,6 @@ function openWindow() {
 
   win.loadURL(`file://${__dirname}/../index.html`)
   if (process.env.NODE_ENV == "development") {
-    fs.watch(`${__dirname}/../../dist`, { recursive: true }, (eventType, filename) => {
-      win.webContents.send("notify-update", filename)
-    })
     win.webContents.openDevTools()
   }
 


### PR DESCRIPTION
## What
- Provide live-reload feature, without any servers.
## Notes

I know this seems odd and looks like monkey-patch. Although I tried `webpack-dev-server` first, it does not work. `webpack-dev-server` needs embed script tags to work but electron renderer process cannot to be directly embedded without `require()` function calling. Of course `require()` needs a target to be located on local, so it cannot to be done with usual process in web application...
