### PR TITLE
Reduce references from child class to parent class

### DIFF
--- a/src/renderer/commands/LayerCommand.ts
+++ b/src/renderer/commands/LayerCommand.ts
@@ -127,7 +127,7 @@ class GroupLayerCommand {
       const src = srcSiblings.splice(srcIndex, 1)[0]
       srcs.unshift(src)
     }
-    const group = new Layer(this.picture, "Group", layer => new GroupLayerContent(layer, srcs))
+    const group = new Layer(this.picture, "Group", layer => new GroupLayerContent(this.picture, layer, srcs))
 
     const [dstSiblings, dstIndex] = getSiblingsAndIndex(this.picture, this.srcPaths[0])
     dstSiblings.splice(dstIndex, 0, group)
@@ -151,7 +151,7 @@ class AddLayerCommand {
   }
   redo() {
     const [siblings, index] = getSiblingsAndIndex(this.picture, this.path)
-    const layer = new Layer(this.picture, "Layer", layer => new ImageLayerContent(layer))
+    const layer = new Layer(this.picture, "Layer", layer => new ImageLayerContent(this.picture, layer))
     siblings.splice(index, 0, layer)
     this.picture.selectedLayers.replace([layer])
   }
@@ -232,7 +232,7 @@ class ChangeLayerImageCommand {
     if (!content) {
       return
     }
-    const {layer} = content
+    const layer = this.picture.layerFromPath(this.path)
 
     const {rect} = this
     const texture = new Texture(context, {
@@ -242,7 +242,7 @@ class ChangeLayerImageCommand {
     })
     content.tiledTexture.drawTexture(texture, {offset: rect.topLeft, blendMode: "src"})
     texture.dispose()
-    content.layer.picture.lastUpdate = {rect, layer}
+    this.picture.lastUpdate = {rect, layer}
     content.updateThumbnail()
   }
 
@@ -272,9 +272,10 @@ class TransformLayerCommand {
     if (!content) {
       return
     }
+    const layer = this.picture.layerFromPath(this.path)
     const old = content.tiledTexture
     content.tiledTexture = tiledTexture.transform(transform)
     old.dispose()
-    this.picture.lastUpdate = {layer: content.layer}
+    this.picture.lastUpdate = {layer: layer}
   }
 }

--- a/src/renderer/models/Layer.ts
+++ b/src/renderer/models/Layer.ts
@@ -23,7 +23,7 @@ class Layer {
   parent: Layer|undefined
   public readonly content: LayerContent
 
-  constructor(public picture: Picture, name: string, makeContent: (layer: Layer) => LayerContent) {
+  constructor(private picture: Picture, name: string, makeContent: (layer: Layer) => LayerContent) {
     this.name = name
     this.content = makeContent(this)
     reaction(() => [this.visible, this.blendMode, this.opacity], () => {
@@ -78,9 +78,9 @@ class Layer {
       switch (data.content.type) {
         default:
         case "image":
-          return ImageLayerContent.fromData(layer, data.content)
+          return ImageLayerContent.fromData(picture, layer, data.content)
         case "group":
-          return GroupLayerContent.fromData(layer, data.content)
+          return GroupLayerContent.fromData(picture, layer, data.content)
       }
     }
     const layer = new Layer(picture, data.name, makeContent)

--- a/src/renderer/models/Picture.ts
+++ b/src/renderer/models/Picture.ts
@@ -4,7 +4,6 @@ import {Vec2, Rect} from "paintvec"
 import {Texture} from "paintgl"
 import Layer, {LayerData} from "./Layer"
 import {GroupLayerContent, ImageLayerContent} from "./LayerContent"
-import ThumbnailGenerator from "./ThumbnailGenerator"
 import LayerBlender from "./LayerBlender"
 import {UndoStack} from "./UndoStack"
 import Navigation from "./Navigation"
@@ -25,7 +24,6 @@ interface PictureUpdate {
 export default
 class Picture {
   readonly size = new Vec2(this.params.width, this.params.height)
-  readonly thumbnailGenerator = new ThumbnailGenerator(this.size)
   readonly rootLayer: Layer
   readonly selectedLayers = observable<Layer>([])
   readonly layerBlender = new LayerBlender(this)
@@ -51,9 +49,9 @@ class Picture {
   }
 
   constructor(public params: PictureParams) {
-    const defaultLayer = new Layer(this, "Layer", layer => new ImageLayerContent(layer))
+    const defaultLayer = new Layer(this, "Layer", layer => new ImageLayerContent(this, layer))
     this.rootLayer = new Layer(this, "root", layer =>
-      new GroupLayerContent(layer, [defaultLayer])
+      new GroupLayerContent(this, layer, [defaultLayer])
     )
     this.selectedLayers.push(defaultLayer)
 
@@ -73,7 +71,6 @@ class Picture {
   }
 
   dispose() {
-    this.thumbnailGenerator.dispose()
     this.layerBlender.dispose()
     for (const layer of this.layers) {
       layer.dispose()

--- a/src/renderer/tools/BaseBrushTool.ts
+++ b/src/renderer/tools/BaseBrushTool.ts
@@ -108,7 +108,7 @@ abstract class BaseBrushTool extends Tool {
   }
 
   hookLayerBlend(layer: Layer, tileKey: Vec2, tile: Tile|undefined, tileBlender: TileBlender) {
-    if (this.targetContent && this.newTiledTexture && layer == this.targetContent.layer) {
+    if (this.targetContent && this.newTiledTexture && layer == this.currentLayer) {
       if (this.newTiledTexture.has(tileKey)) {
         const {blendMode, opacity} = layer
         tileBlender.blend(this.newTiledTexture.get(tileKey), blendMode, opacity)
@@ -246,7 +246,7 @@ abstract class BaseBrushTool extends Tool {
       return
     }
     const content = this.targetContent
-    if (!content) {
+    if (!content || !this.currentLayer || !this.picture) {
       return
     }
     const oldTiledTexture = content.tiledTexture
@@ -274,10 +274,8 @@ abstract class BaseBrushTool extends Tool {
     this.newTiledTexture = undefined
     oldTiledTexture.dispose()
 
-    const {layer} = content
-    const {picture} = layer
-    const command = new ChangeLayerImageCommand(picture, layer.path(), rect, oldData, newData)
-    picture.undoStack.push(command)
+    const command = new ChangeLayerImageCommand(this.picture, this.currentLayer.path(), rect, oldData, newData)
+    this.picture.undoStack.push(command)
   }
 
   brushSize(waypoint: Waypoint) {

--- a/src/renderer/tools/TransformLayerTool.tsx
+++ b/src/renderer/tools/TransformLayerTool.tsx
@@ -107,8 +107,8 @@ class TransformLayerTool extends Tool {
   }
 
   commit() {
-    if (this.picture && this.currentContent) {
-      const command = new TransformLayerCommand(this.picture, this.currentContent.layer.path(), this.originalTiledTexture, this.oldTransform, this.transform)
+    if (this.picture && this.currentContent && this.currentLayer) {
+      const command = new TransformLayerCommand(this.picture, this.currentLayer.path(), this.originalTiledTexture, this.oldTransform, this.transform)
       this.oldTransform = this.transform
       this.picture.undoStack.redoAndPush(command)
       this.boundingRect = this.currentContent.tiledTexture.boundingRect()
@@ -117,7 +117,7 @@ class TransformLayerTool extends Tool {
 
   hookLayerBlend(layer: Layer, tileKey: Vec2, tile: Tile|undefined, tileBlender: TileBlender) {
     const content = this.currentContent
-    if (this.dragging && content && layer == content.layer) {
+    if (this.dragging && content && layer == this.currentLayer) {
       transformedDrawTarget.clear(new Color(0,0,0,0))
       content.tiledTexture.drawToDrawTarget(transformedDrawTarget, {offset: tileKey.mulScalar(-Tile.width), blendMode: "src", transform: this.transform})
       const {blendMode, opacity} = layer
@@ -128,4 +128,3 @@ class TransformLayerTool extends Tool {
     }
   }
 }
-

--- a/src/renderer/views/LayerDetail.tsx
+++ b/src/renderer/views/LayerDetail.tsx
@@ -1,6 +1,7 @@
 import {computed, observable, action} from "mobx"
 import * as React from "react"
 import {observer} from "mobx-react"
+import Picture from  "../models/Picture"
 import Layer, {LayerBlendMode} from "../models/Layer"
 import RangeSlider from "./components/RangeSlider"
 import {ChangeLayerPropsCommand} from "../commands/LayerCommand"
@@ -18,6 +19,7 @@ const blendModeTexts = new Map<LayerBlendMode, string>([
 ])
 
 interface LayerDetailProps {
+  picture: Picture|undefined
   layer: Layer|undefined
 }
 
@@ -26,9 +28,8 @@ class LayerDetail extends React.Component<LayerDetailProps, {}> {
   oldOpacity = 1
 
   onBlendModeChange = action((e: React.FormEvent<HTMLSelectElement>) => {
-    const {layer} = this.props
-    if (layer) {
-      const {picture} = layer
+    const {picture, layer} = this.props
+    if (picture && layer) {
       const blendMode = (e.target as HTMLSelectElement).value as LayerBlendMode
       picture.undoStack.redoAndPush(new ChangeLayerPropsCommand(picture, layer.path(), {blendMode}))
     }
@@ -38,15 +39,14 @@ class LayerDetail extends React.Component<LayerDetailProps, {}> {
     this.oldOpacity =  layer ? layer.opacity : 1
   })
   onOpacityChange = action((value: number) => {
-    const {layer} = this.props
+    const {picture, layer} = this.props
     if (layer) {
       layer.opacity = value / 100
     }
   })
   onOpacityChangeEnd = action((value: number) => {
-    const {layer} = this.props
-    if (layer) {
-      const {picture} = layer
+    const {picture, layer} = this.props
+    if (picture && layer) {
       const opacity = value / 100
       layer.opacity = this.oldOpacity
       picture.undoStack.redoAndPush(new ChangeLayerPropsCommand(picture, layer.path(), {opacity}))

--- a/src/renderer/views/LayerList.tsx
+++ b/src/renderer/views/LayerList.tsx
@@ -44,9 +44,8 @@ function layerToNode(layer: Layer): LayerNode {
   return {key, children, collapsed, layer}
 }
 
-const LayerListItem = observer((props: {layer: Layer, selected: boolean}) => {
-  const {layer, selected} = props
-  const {picture} = layer
+const LayerListItem = observer((props: {picture: Picture, layer: Layer, selected: boolean}) => {
+  const {picture, layer, selected} = props
 
   const rename = (name: string) => {
     if (layer.name != name) {
@@ -137,13 +136,13 @@ class LayerList extends React.Component<LayerListProps, {}> {
           root={root}
           selectedKeys={new Set(selectedKeys)}
           rowHeight={72}
-          rowContent={({node, selected}) => <LayerListItem layer={node.layer} selected={selected} />}
+          rowContent={({node, selected}) => <LayerListItem picture={picture} layer={node.layer} selected={selected} />}
           onSelectedKeysChange={this.onSelectedKeysChange}
           onCollapsedChange={this.onCollapsedChange}
           onMove={this.onMove}
           onCopy={this.onCopy}
         />
-        <LayerDetail layer={picture && picture.currentLayer} />
+        <LayerDetail picture={picture} layer={picture && picture.currentLayer} />
       </div>
     )
   }


### PR DESCRIPTION
This PR intends to remove circular references and workarounds. A lot of circular references is potentially dangerous, and it is difficult to read.
Like `content.layer` should be replaced with passing `layer` and `content` individually.