### PR TITLE
Simplify LayerBlender hook

### DIFF
--- a/src/renderer/models/LayerBlender.ts
+++ b/src/renderer/models/LayerBlender.ts
@@ -135,7 +135,7 @@ class TileBlender {
 const tileBlenders = [new TileBlender()]
 
 export
-type RenderLayerHook = (layer: Layer, tileKey: Vec2) => {hooked: boolean, tile?: Tile}
+type ReplaceTile = (layer: Layer, tileKey: Vec2) => {replaced: boolean, tile?: Tile}
 
 export default
 class LayerBlender {
@@ -145,7 +145,7 @@ class LayerBlender {
   })
   drawTarget = new TextureDrawTarget(context, this.blendedTexture)
 
-  renderLayerHook: RenderLayerHook|undefined
+  replaceTile: ReplaceTile|undefined
 
   @observable lastBlend: {rect?: Rect} = {}
 
@@ -187,10 +187,10 @@ class LayerBlender {
     }
 
     const tileBlender = tileBlenders[depth]
-    if (this.renderLayerHook) {
-      const {hooked, tile: hookedTile} = this.renderLayerHook(layer, key)
-      if (hooked) {
-        tile = hookedTile
+    if (this.replaceTile) {
+      const {replaced, tile: replacedTile} = this.replaceTile(layer, key)
+      if (replaced) {
+        tile = replacedTile
       }
     }
     if (tile) {

--- a/src/renderer/state/AppState.ts
+++ b/src/renderer/state/AppState.ts
@@ -52,12 +52,12 @@ class AppState {
 
   constructor() {
     reaction(() => [this.currentPictureState, this.currentTool], () => {
-      const hook = this.currentTool.hookLayerRender.bind(this.currentTool)
+      const replaceTile = this.currentTool.replaceTile.bind(this.currentTool)
       for (const pictureState of this.pictureStates) {
         if (pictureState == this.currentPictureState) {
-          pictureState.picture.layerBlender.renderLayerHook = hook
+          pictureState.picture.layerBlender.replaceTile = replaceTile
         } else {
-          pictureState.picture.layerBlender.renderLayerHook = undefined
+          pictureState.picture.layerBlender.replaceTile = undefined
         }
       }
     })

--- a/src/renderer/tools/BaseBrushTool.ts
+++ b/src/renderer/tools/BaseBrushTool.ts
@@ -107,16 +107,16 @@ abstract class BaseBrushTool extends Tool {
     this.renderer.render(rect)
   }
 
-  hookLayerRender(layer: Layer, tileKey: Vec2): {hooked: boolean, tile?: Tile} {
+  replaceTile(layer: Layer, tileKey: Vec2): {replaced: boolean, tile?: Tile} {
     if (this.targetContent && this.newTiledTexture && layer == this.targetContent.layer) {
       if (this.newTiledTexture.has(tileKey)) {
         const {blendMode, opacity} = layer
-        return {hooked: true, tile: this.newTiledTexture.get(tileKey)}
+        return {replaced: true, tile: this.newTiledTexture.get(tileKey)}
       } else {
-        return {hooked: true}
+        return {replaced: true}
       }
     } else {
-      return {hooked: false}
+      return {replaced: false}
     }
   }
 

--- a/src/renderer/tools/Tool.ts
+++ b/src/renderer/tools/Tool.ts
@@ -62,8 +62,8 @@ abstract class Tool {
 
   renderSettings(): JSX.Element { return React.createElement("div") }
   renderOverlayUI(): JSX.Element|undefined { return }
-  hookLayerRender(layer: Layer, tileKey: Vec2): {hooked: boolean, tile?: Tile} {
-    return {hooked: false}
+  replaceTile(layer: Layer, tileKey: Vec2): {replaced: boolean, tile?: Tile} {
+    return {replaced: false}
   }
 }
 export default Tool

--- a/src/renderer/tools/TransformLayerTool.tsx
+++ b/src/renderer/tools/TransformLayerTool.tsx
@@ -404,7 +404,7 @@ class TransformLayerTool extends Tool {
     }
   }
 
-  hookLayerRender(layer: Layer, tileKey: Vec2): {hooked: boolean, tile?: Tile} {
+  replaceTile(layer: Layer, tileKey: Vec2): {replaced: boolean, tile?: Tile} {
     const content = this.currentContent
     if (this.editing && content && layer == content.layer && this.originalRect && this.originalTexture) {
       transformedDrawTarget.clear(new Color(0,0,0,0))
@@ -412,9 +412,9 @@ class TransformLayerTool extends Tool {
         .merge(this.transform)
         .translate(tileKey.mulScalar(-Tile.width))
       drawTexture(transformedDrawTarget, this.originalTexture, {transform, blendMode: "src", bicubic: true, srcRect: this.originalTextureSubrect})
-      return {hooked: true, tile: transformedTile}
+      return {replaced: true, tile: transformedTile}
     } else {
-      return {hooked: false}
+      return {replaced: false}
     }
   }
 


### PR DESCRIPTION
Simplify LayerBlender hook used to customize layer blend result in tools

* Rename hookLayerBlend -> replaceTile
* replaceTile now just returns substitute tile