### PR TITLE
Use inline-source-map in webpack devtool

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,7 +96,7 @@ module.exports = {
     new webpack.NamedModulesPlugin(),
     require("webpack-fail-plugin"),
   ],
-  devtool: "eval-cheap-module-source-map",
+  devtool: "inline-source-map",
   devServer: {
     contentBase: './dist',
     port: 23000,


### PR DESCRIPTION
`eval-cheap-module-source-map` makes Error stack trace incorrect.